### PR TITLE
Add TranslateInterpreter for translation commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openwispr",
   "productName": "OpenWispr",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "OpenWispr is an open-source desktop voice productivity tool inspired by WisprFlow. It allows you to transcribe speech and generate **code or terminal commands directly from spoken language** using global hotkeys.",
   "main": ".vite/build/main.js",
   "scripts": {

--- a/src/code-interpreter-factory.ts
+++ b/src/code-interpreter-factory.ts
@@ -4,6 +4,7 @@ import { BashCommandInterpreter } from './interpreters/bash-command-interpreter'
 import { TypeScriptCodeInterpreter } from './interpreters/typescript-code-interpreter';
 import { PythonCodeInterpreter } from './interpreters/python-code-interpreter';
 import { HotkeyInterpreter } from './interpreters/hotkey-interpreter';
+import { TranslateInterpreter } from './interpreters/translate-interpreter';
 import { CodeLanguage } from './types';
 
 export class CodeInterpreterFactory {
@@ -22,12 +23,14 @@ export class CodeInterpreterFactory {
         return new PythonCodeInterpreter(apiKey);
       case 'hotkeys':
         return new HotkeyInterpreter(apiKey);
+      case 'translate':
+        return new TranslateInterpreter(apiKey);
       default:
         throw new Error(`Unsupported code language: ${language}`);
     }
   }
 
   static getSupportedLanguages(): CodeLanguage[] {
-    return ['bash', 'javascript', 'typescript', 'python', 'hotkeys'];
+    return ['bash', 'javascript', 'typescript', 'python', 'hotkeys', 'translate'];
   }
 }

--- a/src/interpreters/translate-interpreter.ts
+++ b/src/interpreters/translate-interpreter.ts
@@ -1,0 +1,111 @@
+import { BaseCodeInterpreter } from './base-code-interpreter';
+
+export class TranslateInterpreter extends BaseCodeInterpreter {
+  protected getSystemPrompt(): string {
+    return `## LLM Prompt – Speech-to-Translation Interpreter
+
+### Model Role
+
+You are a **speech-to-translation interpreter**.
+Your job is to translate text from one language to another based on the user's request.
+
+---
+
+### Core Rules
+
+1. Analyze the input to identify:
+   - The text to translate (the content to be translated)
+   - The target language (specified by phrases like "to French", "to Spanish", etc.)
+   - If no target language is specified, default to **English**
+2. Return **ONLY the translated text**, as a **single string**, with no explanations.
+3. Do **not** add comments, explanations, markdown code blocks, or extra formatting.
+4. **CRITICAL**: Return ONLY the translated text, without wrapping it in markdown code blocks or backticks.
+5. Preserve the original meaning, tone, and style of the input text.
+6. Handle common language names (e.g., "French", "Spanish", "German", "Italian", "Portuguese", "Japanese", "Chinese", etc.)
+7. Detect the source language automatically if not specified.
+8. If the input is purely conversational and not a translation request, return it unchanged.
+
+---
+
+### Examples
+
+**Input**
+
+\`\`\`
+translate hello world to French
+\`\`\`
+
+**Output**
+
+\`\`\`
+Bonjour le monde
+\`\`\`
+
+---
+
+**Input**
+
+\`\`\`
+translate how are you to Spanish
+\`\`\`
+
+**Output**
+
+\`\`\`
+¿Cómo estás?
+\`\`\`
+
+---
+
+**Input**
+
+\`\`\`
+translate good morning
+\`\`\`
+
+**Output**
+
+\`\`\`
+Good morning
+\`\`\`
+
+*(Note: Default to English when no target language specified)*
+
+---
+
+**Input**
+
+\`\`\`
+translate I love programming to Portuguese
+\`\`\`
+
+**Output**
+
+\`\`\`
+Eu amo programação
+\`\`\`
+
+---
+
+**Input**
+
+\`\`\`
+It is a beautiful day
+\`\`\`
+
+**Output**
+
+\`\`\`
+It is a beautiful day
+\`\`\`
+
+*(Note: No translation intent detected, return unchanged)*
+
+---
+
+### Final Decision Rule
+
+* If the text **expresses a clear translation request** (includes "translate" keyword), translate to the specified target language (or English if not specified).
+* If the text is **purely conversational or not a translation request**, do not transform it.`;
+  }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -193,14 +193,16 @@
             "javascript": "javascript",
             "typescript": "typescript",
             "python": "python",
-            "hotkeys": "hotkeys"
+            "hotkeys": "hotkeys",
+            "translate": "translate"
         },
         "descriptions": {
             "command": "Generate bash/terminal commands",
             "javascript": "Generate JavaScript code",
             "typescript": "Generate TypeScript code",
             "python": "Generate Python code",
-            "hotkeys": "Send keyboard shortcuts to focused window"
+            "hotkeys": "Send keyboard shortcuts to focused window",
+            "translate": "Translate text to another language"
         }
     }
 }

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -193,14 +193,16 @@
             "javascript": "javascript",
             "typescript": "typescript",
             "python": "python",
-            "hotkeys": "hotkeys"
+            "hotkeys": "hotkeys",
+            "translate": "traduzir"
         },
         "descriptions": {
             "command": "Gerar comandos bash/terminal",
             "javascript": "Gerar código JavaScript",
             "typescript": "Gerar código TypeScript",
             "python": "Gerar código Python",
-            "hotkeys": "Enviar atalhos de teclado para a janela focada"
+            "hotkeys": "Enviar atalhos de teclado para a janela focada",
+            "translate": "Traduzir texto para outro idioma"
         }
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,7 +58,7 @@ export interface RecordingState {
   audioBuffer?: Buffer[];
 }
 
-export type CodeLanguage = 'bash' | 'javascript' | 'typescript' | 'python' | 'hotkeys';
+export type CodeLanguage = 'bash' | 'javascript' | 'typescript' | 'python' | 'hotkeys' | 'translate';
 
 export interface VoiceCommandResult {
   language: CodeLanguage;

--- a/src/voice-command-detector.ts
+++ b/src/voice-command-detector.ts
@@ -89,6 +89,7 @@ export class VoiceCommandDetector {
     const typescriptKeyword = i18nMain.t('voiceCommands.keywords.typescript');
     const pythonKeyword = i18nMain.t('voiceCommands.keywords.python');
     const hotkeysKeyword = i18nMain.t('voiceCommands.keywords.hotkeys');
+    const translateKeyword = i18nMain.t('voiceCommands.keywords.translate');
 
     // Map keywords to languages
     // Note: Some keywords might be the same across languages (e.g., "javascript")
@@ -97,6 +98,7 @@ export class VoiceCommandDetector {
     keywordMap.set('typescript', [typescriptKeyword]);
     keywordMap.set('python', [pythonKeyword]);
     keywordMap.set('hotkeys', [hotkeysKeyword]);
+    keywordMap.set('translate', [translateKeyword]);
 
     return keywordMap;
   }

--- a/tests/unit/code-interpreter-factory.test.ts
+++ b/tests/unit/code-interpreter-factory.test.ts
@@ -4,6 +4,7 @@ import { JavaScriptCodeInterpreter } from '@/interpreters/javascript-code-interp
 import { BashCommandInterpreter } from '@/interpreters/bash-command-interpreter';
 import { TypeScriptCodeInterpreter } from '@/interpreters/typescript-code-interpreter';
 import { PythonCodeInterpreter } from '@/interpreters/python-code-interpreter';
+import { TranslateInterpreter } from '@/interpreters/translate-interpreter';
 
 describe('CodeInterpreterFactory', () => {
   describe('createInterpreter', () => {
@@ -31,6 +32,12 @@ describe('CodeInterpreterFactory', () => {
       expect(interpreter).toBeInstanceOf(PythonCodeInterpreter);
     });
 
+    it('should create TranslateInterpreter for translate language', () => {
+      const interpreter = CodeInterpreterFactory.createInterpreter('translate', 'test-api-key');
+
+      expect(interpreter).toBeInstanceOf(TranslateInterpreter);
+    });
+
     it('should throw error for unsupported language', () => {
       expect(() => {
         CodeInterpreterFactory.createInterpreter('unsupported' as any, 'test-api-key');
@@ -51,13 +58,13 @@ describe('CodeInterpreterFactory', () => {
     it('should return all supported languages', () => {
       const languages = CodeInterpreterFactory.getSupportedLanguages();
 
-      expect(languages).toEqual(['bash', 'javascript', 'typescript', 'python', 'hotkeys']);
+      expect(languages).toEqual(['bash', 'javascript', 'typescript', 'python', 'hotkeys', 'translate']);
     });
 
-    it('should return array with 4 languages', () => {
+    it('should return array with 6 languages', () => {
       const languages = CodeInterpreterFactory.getSupportedLanguages();
 
-      expect(languages).toHaveLength(5);
+      expect(languages).toHaveLength(6);
     });
 
     it('should include bash in supported languages', () => {
@@ -82,6 +89,12 @@ describe('CodeInterpreterFactory', () => {
       const languages = CodeInterpreterFactory.getSupportedLanguages();
 
       expect(languages).toContain('python');
+    });
+
+    it('should include translate in supported languages', () => {
+      const languages = CodeInterpreterFactory.getSupportedLanguages();
+
+      expect(languages).toContain('translate');
     });
   });
 });

--- a/tests/unit/voice-command-detector.test.ts
+++ b/tests/unit/voice-command-detector.test.ts
@@ -10,6 +10,7 @@ vi.mock('@/i18n-main', () => ({
         'voiceCommands.keywords.javascript': 'javascript',
         'voiceCommands.keywords.typescript': 'typescript',
         'voiceCommands.keywords.python': 'python',
+        'voiceCommands.keywords.translate': 'translate',
       };
       return translations[key] || key;
     }),
@@ -54,6 +55,14 @@ describe('VoiceCommandDetector', () => {
       expect(result.language).toBe('python');
       expect(result.strippedTranscription).toBe('print hello world');
       expect(result.detectedKeyword).toBe('python');
+    });
+
+    it('should detect "translate" keyword and return translate language', () => {
+      const result = VoiceCommandDetector.detectCommand('translate hello world to French', 'en');
+
+      expect(result.language).toBe('translate');
+      expect(result.strippedTranscription).toBe('hello world to French');
+      expect(result.detectedKeyword).toBe('translate');
     });
   });
 
@@ -171,6 +180,7 @@ describe('detectCommand - Portuguese Locale', () => {
         'voiceCommands.keywords.javascript': 'javascript',
         'voiceCommands.keywords.typescript': 'typescript',
         'voiceCommands.keywords.python': 'python',
+        'voiceCommands.keywords.translate': 'traduzir',
       };
       return translations[key] || key;
     });
@@ -195,6 +205,14 @@ describe('detectCommand - Portuguese Locale', () => {
 
     expect(result.language).toBe('javascript');
     expect(result.strippedTranscription).toBe('criar função');
+  });
+
+  it('should detect Portuguese "traduzir" keyword', () => {
+    const result = VoiceCommandDetector.detectCommand('traduzir olá mundo para francês', 'pt-BR');
+
+    expect(result.language).toBe('translate');
+    expect(result.strippedTranscription).toBe('olá mundo para francês');
+    expect(result.detectedKeyword).toBe('traduzir');
   });
 });
 
@@ -234,10 +252,11 @@ describe('detectCommand - Portuguese Locale', () => {
   describe('detectCommand - All Language Types', () => {
     it('should correctly map all supported languages', () => {
       const testCases = [
-        { input: 'command list files', expected: 'bash' }, // Use same pattern as working tests
+        { input: 'command list files', expected: 'bash' },
         { input: 'javascript create function', expected: 'javascript' },
         { input: 'typescript interface user', expected: 'typescript' },
         { input: 'python print hello', expected: 'python' },
+        { input: 'translate hello world to French', expected: 'translate' },
       ];
 
       testCases.forEach(({ input, expected }) => {


### PR DESCRIPTION
Introduce a new `TranslateInterpreter` to handle translation commands, allowing users to translate text between languages. Update the application to support the new interpreter and include relevant tests and documentation.