### PR TITLE
Fix duplicate test results comments

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,11 +1,6 @@
 name: PR Tests
 
 on:
-  pull_request:
-    branches:
-      - main
-      - develop
-      - dev
   pull_request_target:
     branches:
       - main


### PR DESCRIPTION
The workflow was configured with both 'pull_request' and 'pull_request_target' triggers for the same branches, causing tests to run twice and post duplicate comments. Keeping only 'pull_request_target' which has the necessary permissions to comment on PRs from both the repository and forks.

Fixes the duplicate test results comments issue.