### PR TITLE
Add recording cancellation feature with Space hotkey

### DIFF
--- a/src/ditossauro-app.ts
+++ b/src/ditossauro-app.ts
@@ -192,6 +192,31 @@ export class DitossauroApp extends EventEmitter {
     }
   }
 
+  async cancelRecording(): Promise<void> {
+    if (!this.recordingState.isRecording) {
+      console.log('⚠️ Not recording, nothing to cancel');
+      return;
+    }
+
+    console.log('❌ Canceling recording...');
+
+    try {
+      if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+        await this.mainWindow.webContents.executeJavaScript(`
+          window.audioRecorder.cancelRecording()
+        `);
+      }
+
+      this.recordingState.isRecording = false;
+      this.recordingState.startTime = undefined;
+      this.emit('recording-canceled');
+      console.log('✅ Recording canceled successfully');
+    } catch (error) {
+      console.error('Error canceling recording:', error);
+      this.emit('error', error);
+    }
+  }
+
   private async processRecording(recordingData: { audioFile: string; duration: number }): Promise<void> {
     try {
       this.emit('processing-started');

--- a/src/hotkey-manager.ts
+++ b/src/hotkey-manager.ts
@@ -195,12 +195,21 @@ export class HotkeyManager extends EventEmitter {
    * Checks if any key combination is pressed
    */
   private checkHotkeys(skipStartStop = false): void {
-    // Check cancel key first
-    if (this.cancelKey) {
+    // Check cancel key first - but only if startStop hotkey keys are also pressed
+    if (this.cancelKey && this.startStopConfig) {
       const cancelKeyCode = KEY_CODE_MAP[this.cancelKey];
       if (cancelKeyCode && this.pressedKeys.has(cancelKeyCode)) {
-        this.emit('cancel-pressed');
-        return;
+        // Check if all startStop hotkey keys are also pressed
+        const startStopKeyCodes = this.startStopConfig.keys
+          .map(key => KEY_CODE_MAP[key])
+          .filter(code => code !== undefined);
+
+        const allStartStopKeysPressed = startStopKeyCodes.every(code => this.pressedKeys.has(code));
+
+        if (allStartStopKeysPressed) {
+          this.emit('cancel-pressed');
+          return;
+        }
       }
     }
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1140,7 +1140,7 @@ class DitossauroUI {
           keys: selectedKeys,
           mode: hotkeyMode
         },
-        cancel: 'Escape'
+        cancel: 'Space'
       });
 
       // Notify that hotkeys have been updated

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -16,7 +16,7 @@ export class SettingsManager {
         keys: ['Control', 'Shift', 'Meta'], // Control + Shift + Windows (Meta)
         mode: 'push-to-talk'
       },
-      cancel: 'Escape'
+      cancel: 'Space'
     },
     audio: {
       deviceId: 'default',


### PR DESCRIPTION
## Description

This PR implements a recording cancellation feature that allows users to cancel an active recording without processing it for transcription. The cancel action is now triggered by pressing the Space key (in combination with the start/stop hotkey keys), providing a quick way to discard unwanted recordings.

Fixes #(issue)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring

## Changes Made

### Core Functionality
- **Added `cancelRecording()` method** in `DitossauroApp` to handle recording cancellation on the main process
- **Added `cancelRecording()` method** in the renderer's audio recorder to stop media recording and clear audio chunks without processing
- **Implemented cancel hotkey detection** in `HotkeyManager` that requires both the cancel key (Space) and start/stop hotkey keys to be pressed simultaneously
- **Added event handling** for `recording-canceled` event to update UI, tray icon, and floating window state

### Configuration Changes
- Changed default cancel hotkey from `Escape` to `Space` in both `settings-manager.ts` and `renderer.ts`
- Updated hotkey logic to prevent accidental cancellations by requiring the start/stop hotkey combination to be held

### Event Flow
1. User presses Space + start/stop hotkey combination
2. `HotkeyManager` emits `cancel-pressed` event
3. `DitossauroElectronApp` calls `ditossauroApp.cancelRecording()`
4. Recording is stopped without audio processing
5. UI is updated with `recording-canceled` event
6. Floating window is hidden and tray icon returns to idle state

## How Has This Been Tested?

- [x] Manual testing of cancel hotkey (Space + start/stop keys)
- [x] Verification that recording state is properly reset
- [x] Confirmation that audio is not processed when canceled
- [x] UI updates correctly when recording is canceled

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Code maintains consistency with existing patterns

## Additional Notes

The cancel hotkey now requires pressing Space in combination with the configured start/stop hotkey keys (e.g., Ctrl+Shift+Meta+Space). This prevents accidental cancellations from a single key press and provides a more intentional user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to cancel active recordings using a dedicated hotkey, allowing quick abort of recording sessions.

* **Changes**
  * Default cancel hotkey updated from Escape to Space.
  * Modified cancel hotkey behavior to require simultaneous activation with recording start/stop keys, preventing accidental cancellations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->