### PR TITLE
Add clipboard context capture for transcriptions

### DIFF
--- a/src/ditossauro-app.ts
+++ b/src/ditossauro-app.ts
@@ -324,6 +324,17 @@ export class DitossauroApp extends EventEmitter {
 
       const settings = this.settingsManager.loadSettings();
 
+      // Capture clipboard content AFTER recording stops (user has released hotkeys)
+      // This prevents interference with push-to-talk hotkey combinations
+      if (settings.behavior?.includeClipboardContext) {
+        this.clipboardContext = await this.captureClipboardContext();
+        if (this.clipboardContext) {
+          console.log('📋 Will include clipboard context with transcription');
+        }
+      } else {
+        this.clipboardContext = '';
+      }
+
       // Get language based on provider
       let language = settings.api.language; // Default fallback
       if (settings.transcription.provider === 'groq') {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -138,7 +138,7 @@
             "launchAtStartup": "Launch at startup",
             "launchAtStartupHelp": "Automatically launch Ditossauro when your system starts",
             "includeClipboardContext": "Include selected text as context",
-            "includeClipboardContextHelp": "When enabled, pressing the recording hotkey will trigger Ctrl+C to copy your current selection and include it as context with the transcription. Only newly copied content is sent (not stale clipboard data)."
+            "includeClipboardContextHelp": "When enabled, Ctrl+C will be triggered automatically after you finish recording to copy your current selection and include it as context with the transcription. Only newly copied content is sent (not stale clipboard data)."
         }
     },
     "history": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -137,8 +137,8 @@
             "notifyOnTranscriptionHelp": "Display a system notification each time a transcription is completed",
             "launchAtStartup": "Launch at startup",
             "launchAtStartupHelp": "Automatically launch Ditossauro when your system starts",
-            "includeClipboardContext": "Include clipboard content as context",
-            "includeClipboardContextHelp": "When enabled, the clipboard content will be captured when recording starts and included with the transcription as context"
+            "includeClipboardContext": "Include selected text as context",
+            "includeClipboardContextHelp": "When enabled, pressing the recording hotkey will trigger Ctrl+C to copy your current selection and include it as context with the transcription. Only newly copied content is sent (not stale clipboard data)."
         }
     },
     "history": {
@@ -150,7 +150,7 @@
         "noTranscriptions": "No transcriptions",
         "copy": "Copy",
         "copied": "Copied!",
-        "clipboardContext": "Clipboard Context"
+        "clipboardContext": "Context"
     },
     "about": {
         "title": "About",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -136,7 +136,9 @@
             "notifyOnTranscription": "Show notifications when transcription is completed",
             "notifyOnTranscriptionHelp": "Display a system notification each time a transcription is completed",
             "launchAtStartup": "Launch at startup",
-            "launchAtStartupHelp": "Automatically launch Ditossauro when your system starts"
+            "launchAtStartupHelp": "Automatically launch Ditossauro when your system starts",
+            "includeClipboardContext": "Include clipboard content as context",
+            "includeClipboardContextHelp": "When enabled, the clipboard content will be captured when recording starts and included with the transcription as context"
         }
     },
     "history": {
@@ -147,7 +149,8 @@
         "clearError": "Error clearing history",
         "noTranscriptions": "No transcriptions",
         "copy": "Copy",
-        "copied": "Copied!"
+        "copied": "Copied!",
+        "clipboardContext": "Clipboard Context"
     },
     "about": {
         "title": "About",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -138,7 +138,7 @@
             "launchAtStartup": "Iniciar com o sistema",
             "launchAtStartupHelp": "Iniciar o Ditossauro automaticamente quando o sistema inicializar",
             "includeClipboardContext": "Incluir texto selecionado como contexto",
-            "includeClipboardContextHelp": "Quando ativado, pressionar o atalho de gravação acionará Ctrl+C para copiar sua seleção atual e incluí-la como contexto na transcrição. Apenas conteúdo recém-copiado é enviado (não dados antigos da área de transferência)."
+            "includeClipboardContextHelp": "Quando ativado, Ctrl+C será acionado automaticamente após finalizar a gravação para copiar sua seleção atual e incluí-la como contexto na transcrição. Apenas conteúdo recém-copiado é enviado (não dados antigos da área de transferência)."
         }
     },
     "history": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -137,8 +137,8 @@
             "notifyOnTranscriptionHelp": "Exibir uma notificação do sistema cada vez que uma transcrição for concluída",
             "launchAtStartup": "Iniciar com o sistema",
             "launchAtStartupHelp": "Iniciar o Ditossauro automaticamente quando o sistema inicializar",
-            "includeClipboardContext": "Incluir conteúdo da área de transferência como contexto",
-            "includeClipboardContextHelp": "Quando ativado, o conteúdo da área de transferência será capturado ao iniciar a gravação e incluído com a transcrição como contexto"
+            "includeClipboardContext": "Incluir texto selecionado como contexto",
+            "includeClipboardContextHelp": "Quando ativado, pressionar o atalho de gravação acionará Ctrl+C para copiar sua seleção atual e incluí-la como contexto na transcrição. Apenas conteúdo recém-copiado é enviado (não dados antigos da área de transferência)."
         }
     },
     "history": {
@@ -150,7 +150,7 @@
         "noTranscriptions": "Nenhuma transcrição",
         "copy": "Copiar",
         "copied": "Copiado!",
-        "clipboardContext": "Contexto da Área de Transferência"
+        "clipboardContext": "Contexto"
     },
     "about": {
         "title": "Sobre",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -136,7 +136,9 @@
             "notifyOnTranscription": "Mostrar notificações quando a transcrição for concluída",
             "notifyOnTranscriptionHelp": "Exibir uma notificação do sistema cada vez que uma transcrição for concluída",
             "launchAtStartup": "Iniciar com o sistema",
-            "launchAtStartupHelp": "Iniciar o Ditossauro automaticamente quando o sistema inicializar"
+            "launchAtStartupHelp": "Iniciar o Ditossauro automaticamente quando o sistema inicializar",
+            "includeClipboardContext": "Incluir conteúdo da área de transferência como contexto",
+            "includeClipboardContextHelp": "Quando ativado, o conteúdo da área de transferência será capturado ao iniciar a gravação e incluído com a transcrição como contexto"
         }
     },
     "history": {
@@ -147,7 +149,8 @@
         "clearError": "Erro ao limpar histórico",
         "noTranscriptions": "Nenhuma transcrição",
         "copy": "Copiar",
-        "copied": "Copiado!"
+        "copied": "Copiado!",
+        "clipboardContext": "Contexto da Área de Transferência"
     },
     "about": {
         "title": "Sobre",

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -36,6 +36,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
   downloadUpdate: (downloadUrl: string) => ipcRenderer.invoke('download-update', downloadUrl),
 
+  // Clipboard
+  readClipboard: (): Promise<string> => ipcRenderer.invoke('read-clipboard'),
+
   // Audio processing
   processAudioData: (audioData: number[], duration: number): Promise<{ audioFile: string; duration: number }> =>
     ipcRenderer.invoke('process-audio-data', audioData, duration),
@@ -125,6 +128,7 @@ export interface ElectronAPI {
     error?: string;
   }>;
   downloadUpdate(downloadUrl: string): Promise<{ success: boolean; error?: string }>;
+  readClipboard(): Promise<string>;
   processAudioData(audioData: number[], duration: number): Promise<{ audioFile: string; duration: number }>;
   sendAudioEvent(eventType: string, data?: unknown): void;
   notifyHotkeysUpdated(): void;

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -47,6 +47,7 @@ export class SettingsManager {
       showFloatingWindow: true,
       notifyOnTranscription: true,
       launchAtStartup: false,
+      includeClipboardContext: false,
     }
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface TranscriptionSession {
   duration: number;
   language: string;
   confidence: number;
+  clipboardContext?: string;
 }
 
 export type HotkeyMode = 'toggle' | 'push-to-talk';
@@ -51,6 +52,7 @@ export interface AppSettings {
     showFloatingWindow: boolean; // Show or hide the floating window
     notifyOnTranscription: boolean; // Show notifications when transcriptions are completed
     launchAtStartup: boolean; // Launch application on OS startup
+    includeClipboardContext: boolean; // Include clipboard content as context for transcription
   };
 }
 


### PR DESCRIPTION
## Description

This PR adds the ability to capture and include clipboard content as context when recording transcriptions. When enabled in settings, the clipboard content is automatically captured at the start of a recording and stored alongside the transcription for reference.

This feature is useful for providing additional context to transcriptions, such as code snippets, documentation, or other relevant text that the user may be working with.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

### Core Functionality
- Added `clipboard` import from Electron to enable clipboard access
- Added `clipboardContext` property to `TranscriptionSession` type to store captured clipboard content
- Added `includeClipboardContext` setting to behavior configuration (defaults to `false`)
- Implemented clipboard capture logic in the recording start handler that reads clipboard content when the setting is enabled
- Added IPC handler `read-clipboard` to expose clipboard reading capability to the renderer process

### UI Updates
- Added new toggle setting "Include clipboard content as context" in the behavior settings section
- Updated transcription display to show clipboard context with styled formatting (green accent matching app theme)
- Added clipboard context display in both the last transcription view and history items
- Added localization strings for English and Portuguese (Brazil) for the new feature

### Settings & Types
- Extended `AppSettings.behavior` interface with `includeClipboardContext` boolean flag
- Updated settings manager to initialize the new setting with default value `false`
- Exposed `readClipboard()` method in the Electron API preload bridge

## How Has This Been Tested?

- [x] Verified clipboard capture works when setting is enabled
- [x] Verified clipboard context displays correctly in UI with proper styling
- [x] Verified setting persists across application restarts
- [x] Verified no clipboard capture occurs when setting is disabled
- [x] Verified error handling for clipboard read failures

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (localization strings)
- [x] My changes generate no new warnings
- [x] Backward compatible - new setting defaults to `false` to maintain existing behavior

## Additional Notes

The clipboard context is displayed with a distinctive green accent (`#8BCF3E`) to match the application's design language. The feature is opt-in via settings to respect user privacy preferences. Error handling is included to gracefully handle clipboard access failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optionally capture and attach freshly copied clipboard text to transcriptions (captured after recording ends; only new selection is sent).

* **Settings / UI**
  * New toggle to enable/disable clipboard context; recent transcription and history show a clipboard-context block when present.

* **Localization**
  * Added English and Portuguese strings for the clipboard-context setting, help text, and history label.

* **Platform Integration**
  * UI can request clipboard text and clipboard context is included in transcription payloads when enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->